### PR TITLE
Add first draft of dns-sd testing

### DIFF
--- a/dnssd/.dockerignore
+++ b/dnssd/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/dnssd/.gitignore
+++ b/dnssd/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/dnssd/README.md
+++ b/dnssd/README.md
@@ -1,0 +1,9 @@
+# Testing DNS-SD in Web of Things
+
+See https://www.w3.org/TR/wot-discovery/#introduction-dns-sd
+
+# Run
+
+`node command.js` 
+
+See `node commmand.js --help` for further infos

--- a/dnssd/command.js
+++ b/dnssd/command.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const MDNSWoTTest = require('./index')
+
+
+yargs(hideBin(process.argv))
+    .scriptName('wot-testing-dns-sd')
+    .command('$0 [file]', 'A simple utility to test a discoverer and a discoveree according to https://www.w3.org/TR/wot-discovery/#introduction-dns-sd', () => { }, async (argv) => {
+        const testSuite = new MDNSWoTTest();
+        const results = [];
+
+        const file = argv.file ? argv.file : 'dns-sd-test.csv'
+        const kind = argv.kind ? argv.kind : '*'
+
+        const resultDiscovererThing = (kind === 'thing' || kind === '*') && testSuite.testDiscovererThing(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_thing', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_thing', 'status': 'fail', comment: e.message })
+        })
+
+        const resultDiscovererDirectory = (kind === 'directory' || kind === '*') && testSuite.testDiscovererDirectory(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_directory', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_directory', 'status': 'fail', comment: e.message })
+        })
+
+        await Promise.all([resultDiscovererThing, resultDiscovererDirectory])
+
+        const resultDiscovereeThing = (kind === 'thing' || kind === '*') && testSuite.testDiscovereeThing(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_thing', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_thing', 'status': 'fail', comment: e.message })
+        })
+
+        const resultDiscovereeDirectory = (kind === 'directory' || kind === '*') && testSuite.testDiscovereeDirectory(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_directory', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_directory', 'status': 'fail', comment: e.message })
+        })
+
+        await Promise.all([resultDiscovereeThing, resultDiscovereeDirectory]);
+
+        await writeResult(results, file, argv.append)
+
+        !argv.quiet && printReports(results)
+
+        testSuite.close()
+    })
+    .command('discoverer [file]', 'testing a discoverer (whom issues queries)', () => { }, async (argv) => {
+        const testSuite = new MDNSWoTTest();
+        const results = [];
+
+        const file = argv.file ? argv.file : 'dns-sd-test.csv'
+        const kind = argv.kind ? argv.kind : '*'
+
+        const resultDiscovererThing = (kind === 'thing' || kind === '*') && testSuite.testDiscovererThing(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_thing', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_thing', 'status': 'fail', comment: e.message })
+        })
+
+        const resultDiscovererDirectory = (kind === 'directory' || kind === '*') && testSuite.testDiscovererDirectory(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_directory', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoverer_directory', 'status': 'fail', comment: e.message })
+        })
+
+        await Promise.all([resultDiscovererThing, resultDiscovererDirectory])
+
+        await writeResult(results, file, argv.append)
+
+        !argv.quiet && printReports(results)
+
+        testSuite.close()
+    })
+    .command('discoveree [file]', 'testing an exposed Thing', () => { }, async (argv) => {
+        const testSuite = new MDNSWoTTest();
+        const results = [];
+
+        const file = argv.file ? argv.file : 'dns-sd-test.csv'
+        const kind = argv.kind ? argv.kind : '*'
+
+        const resultDiscovereeThing = (kind === 'thing' || kind === '*') && testSuite.testDiscovereeThing(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_thing', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_thing', 'status': 'fail', comment: e.message })
+        })
+
+        const resultDiscovereeDirectory = (kind === 'directory' || kind === '*') && testSuite.testDiscovereeDirectory(argv.timeout).then(() => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_directory', 'status': 'pass', comment: '' })
+        }).catch((e) => {
+            results.push({ id: 'introduction-dns-sd-service-name_discoveree_directory', 'status': 'fail', comment: e.message })
+        })
+
+        await Promise.all([resultDiscovereeThing, resultDiscovereeDirectory]);
+
+        await writeResult(results, file, argv.append)
+        
+        !argv.quiet && printReports(results)
+
+        testSuite.close()
+    })
+    .env('WOT_DNS_SD_TESTER')
+    .default('append', false)
+    .option('append', {
+        alias: 'a',
+        type: 'boolean',
+        description: 'Append the test result to file'
+    })
+    .default('timeout', 5000)
+    .option('timeout', {
+        alias: 't',
+        type: 'number',
+        description: 'Total maximum milliseconds of the test',
+    })
+    .option('kind', {
+        alias: 'k',
+        describe: 'Choose to test for Thing Directory or both',
+        choices: ['thing', 'directory', '*']
+    })
+    .option('quiet', {
+        alias: 'q',
+        describe: 'Do not print results'
+    })
+    .example('wot_dnssd_tester discover --kind thing test only queries for Thing')
+
+    .argv
+
+async function writeResult(results, file, append) {
+    const createCsvWriter = require('csv-writer').createObjectCsvWriter;
+    const csvWriter = createCsvWriter({
+        path: file,
+        header: [
+            { id: 'id', title: 'ID' },
+            { id: 'status', title: 'Status' },
+            { id: 'comment', title: 'Comment' },
+        ],
+        append: append
+    });
+
+    await csvWriter.writeRecords(results)
+
+}
+
+function printReports(results){
+    console.log('assertion\t\t\t\t\t\tstatus\tcomment\n')
+    for (const report of results) {
+        console.log(`${report.id}\t${report.status}\t${report.comment}`)
+    }
+}
+

--- a/dnssd/dockerfile
+++ b/dnssd/dockerfile
@@ -1,0 +1,16 @@
+FROM node:12-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+ENTRYPOINT [ "node", "command.js" ]

--- a/dnssd/index.js
+++ b/dnssd/index.js
@@ -1,0 +1,162 @@
+const MDNS = require('multicast-dns');
+const fetch = require('node-fetch');
+class MDNSWoTTestSuite {
+    constructor() {
+        this.mdns = MDNS();
+    }
+
+    testDiscovererThing(timeout) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.mdns.removeListener('query', handler)
+                reject(new Error("timeout"))
+            }, timeout);
+
+            function handler(query) {
+                for (const question of query.questions) {
+                    if (question.name.startsWith("_wot")) {
+                        clearTimeout(timer)
+                        this.removeListener('query', handler)
+                        resolve()
+                    }
+                }
+            }
+            this.mdns.on('query', handler)
+        })
+    }
+
+    testDiscovererDirectory(timeout) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.mdns.removeListener('query', handler)
+                reject(new Error("timeout"))
+            }, timeout);
+
+            function handler(query) {
+                for (const question of query.questions) {
+                    if (question.name.startsWith("_directory._sub._wot")) {
+                        clearTimeout(timer)
+                        this.removeListener('query', handler)
+                        resolve(true)
+                    }
+                }
+            }
+            this.mdns.on('query', handler)
+        })
+    }
+
+    testDiscovereeThing(timeout) {
+        return new Promise((resolve, reject) => {
+
+
+            const interval = setInterval(() => {
+                this.mdns.query('_wot._tcp.local', 'PTR')
+            }, 1000);
+            async function handler(packet) {
+                const ans = packet.answers.find(ans => ans.type === 'PTR' && ans.name === '_wot._tcp.local')
+                if (ans) {
+                    const svr = packet.additionals.find(ans => ans.type === 'SRV')
+                    const txt = packet.additionals.find(ans => ans.type === 'TXT')
+                    const port = svr && svr.data.port
+                    const host = svr && svr.data.target
+
+                    const rawTxtData = txt && txt.data.toString()
+                    const regex = /^td=(?<path>.*),type=(?<type>.*)/;
+                    const match = regex.exec(rawTxtData)
+                    if (match) {
+                        clearTimeout(timer)
+                        clearInterval(interval)
+                        this.removeListener('response', handler)
+
+                        const path = match.groups.path
+                        const type = match.groups.type
+
+                        if (type !== 'Thing') {
+                            reject(new Error("Wrong type advertised:", type))
+                            return
+                        }
+
+                        const fullPath = `http://${host}:${port}${path}`
+
+                        const res = await fetch(fullPath)
+
+                        if (res.status !== 200) {
+                            reject(new Error("Wrong address advertised:", fullPath))
+                            return
+                        }
+
+                        resolve()
+                    }
+                }
+            }
+
+            this.mdns.on('response', handler)
+            const timer = setTimeout(() => {
+                clearInterval(interval)
+                this.mdns.removeListener('response', handler);
+                reject(new Error("timeout"))
+            }, timeout);
+        })
+    }
+
+    testDiscovereeDirectory(timeout) {
+        return new Promise((resolve, reject) => {
+            const interval = setInterval(() => {
+                this.mdns.query('_directory._sub._wot', 'PTR')
+            }, 1000);
+
+            async function handler(packet) {
+                const ans = packet.answers.find(ans => ans.type === 'PTR' && ans.name === '_directory._sub._wot')
+                if (ans) {
+                    const svr = packet.additionals.find(ans => ans.type === 'SRV')
+                    const txt = packet.additionals.find(ans => ans.type === 'TXT')
+                    const port = svr && svr.data.port
+                    const host = svr && svr.data.target
+
+                    const rawTxtData = txt && txt.data.toString()
+                    const regex = /^td=(?<path>.*),type=(?<type>.*)/;
+                    const match = regex.exec(rawTxtData)
+                    if (match) {
+                        clearTimeout(timer)
+                        clearInterval(interval)
+                        this.removeListener('response', handler)
+
+                        const path = match.groups.path
+                        const type = match.groups.type
+
+                        if (type !== 'Directory') {
+                            reject(new Error("Wrong type advertised:", type))
+                            return
+                        }
+
+                        const fullPath = `http://${host}:${port}${path}`
+
+                        const res = await fetch(fullPath)
+
+                        if (res.status !== 200) {
+                            reject(new Error("Wrong address advertised:", fullPath))
+                            return
+                        }
+
+                        resolve()
+                    }
+                }
+            }
+
+            this.mdns.on('response', handler)
+            const timer = setTimeout(() => {
+                clearInterval(interval)
+                this.mdns.removeListener('response', handler);
+                reject(new Error("timeout"))
+            }, timeout);
+        })
+    }
+
+    close(callback) {
+        this.mdns.removeAllListeners()
+        this.mdns.destroy(callback)
+    }
+}
+
+
+module.exports = MDNSWoTTestSuite

--- a/dnssd/package-lock.json
+++ b/dnssd/package-lock.json
@@ -1,0 +1,158 @@
+{
+  "name": "testingdns",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
+    },
+    "dns-packet": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.4.tgz",
+      "integrity": "sha512-vgu5Bx5IV8mXmh/9cn1lzn+J7okFlXe1vBRp+kCBJXg1nBED6Z/Q4e+QaDxQRSozMr14p/VQmdXwsf/I2wGjUA==",
+      "requires": {
+        "ip": "^1.1.5"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "multicast-dns": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.3.tgz",
+      "integrity": "sha512-TzxgGSLRLB7tqAlzjgd2x2ZE0cDsGFq4rs9W4yE5xp+7hlRXeUQGtXZsTGfGw2FwWB45rfe8DtXMYBpZGMLUng==",
+      "requires": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+    }
+  }
+}

--- a/dnssd/package.json
+++ b/dnssd/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wot-testing-dns-sd",
+  "version": "1.1.0",
+  "description": "Testing accordingly https://www.w3.org/TR/wot-discovery/#introduction-dns-sd",
+  "bin": "command.js",
+  "main": "index.js",
+  "scripts": {
+    "start": "node command.js"
+  },
+  "author": "Cristiano Aguzzi",
+  "license": "ISC",
+  "dependencies": {
+    "csv-writer": "^1.6.0",
+    "multicast-dns": "^7.2.3",
+    "node-fetch": "^2.6.1",
+    "yargs": "^17.0.1"
+  }
+}


### PR DESCRIPTION
Hi! this is the basic script that I was working on these days. Not sure if it is super useful but it tests both roles when using MDNS / SD for WoT discovery. It can be used also from the command line and it has a bunch of configurations (e.g. which role you want to test or type). It might be reused inside node-wot or webthings.io to assert compliance to the spec. 