### PR TITLE
TD title matching instead of JSON comparison

### DIFF
--- a/directory/notification_test.go
+++ b/directory/notification_test.go
@@ -145,10 +145,7 @@ func TestCreateEvent(t *testing.T) {
 				// remove system-generated attributes
 				delete(data, "registration")
 
-				if !serializedEqual(td, data) {
-					t.Fatalf("notification data is not same as the one created: Expected:\n%v\nRetrieved:\n%v", marshalPrettyJSON(td), marshalPrettyJSON(data))
-				}
-
+				assertEqualTitle(t, td, data)
 			})
 		case err := <-errCh:
 			t.Run("event subscription diff unsupported", func(t *testing.T) {

--- a/directory/search_test.go
+++ b/directory/search_test.go
@@ -88,10 +88,7 @@ func TestJSONPath(t *testing.T) {
 				// remove system-generated attributes
 				delete(filterredTD, "registration")
 
-				if !serializedEqual(createdTDsMap[id], filterredTD) {
-					t.Fatalf("Expected:\n%v\nGot:\n%v\n",
-						marshalPrettyJSON(createdTDsMap[id]), marshalPrettyJSON(filterredTD))
-				}
+				assertEqualTitle(t, createdTDsMap[id], filterredTD)
 			}
 		})
 	})
@@ -231,10 +228,7 @@ func TestXPath(t *testing.T) {
 				// remove system-generated attributes
 				delete(filterredTD, "registration")
 
-				if !serializedEqual(createdTDsMap[id], filterredTD) {
-					t.Fatalf("Expected:\n%v\nGot:\n%v\n",
-						marshalPrettyJSON(createdTDsMap[id]), marshalPrettyJSON(filterredTD))
-				}
+				assertEqualTitle(t, createdTDsMap[id], filterredTD)
 			}
 		})
 	})
@@ -332,10 +326,7 @@ func TestSPARQL(t *testing.T) {
 		t.Log(responseMap)
 		delete(responseMap, "results")
 
-		if !serializedEqual(responseMap, expectedResult) {
-			t.Fatalf("Expected:\n%v\nGot:\n%v\n",
-				marshalPrettyJSON(expectedResult), marshalPrettyJSON(responseMap))
-		}
+		assertEqualTitle(t, expectedResult, responseMap)
 	})
 
 	t.Run("search using POST", func(t *testing.T) {
@@ -363,10 +354,7 @@ func TestSPARQL(t *testing.T) {
 		t.Log(responseMap)
 		delete(responseMap, "results")
 
-		if !serializedEqual(responseMap, expectedResult) {
-			t.Fatalf("Expected:\n%v\nGot:\n%v\n",
-				marshalPrettyJSON(expectedResult), marshalPrettyJSON(responseMap))
-		}
+		assertEqualTitle(t, expectedResult, responseMap)
 	})
 
 	t.Run("federated search using GET", func(t *testing.T) {
@@ -393,10 +381,7 @@ func TestSPARQL(t *testing.T) {
 		t.Log(responseMap)
 		delete(responseMap, "results")
 
-		if !serializedEqual(responseMap, expectedResult) {
-			t.Fatalf("Expected:\n%v\nGot:\n%v\n",
-				marshalPrettyJSON(expectedResult), marshalPrettyJSON(responseMap))
-		}
+		assertEqualTitle(t, expectedResult, responseMap)
 	})
 
 	t.Run("HEAD", func(t *testing.T) {

--- a/directory/things_test.go
+++ b/directory/things_test.go
@@ -29,7 +29,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 			"tdd-things-create-anonymous-contenttype")
 
 		// submit POST request
-		res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
+		res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("Error posting: %s", err)
 		}
@@ -84,9 +84,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 		delete(storedTD, "registration")
 		delete(storedTD, "id")
 
-		if !serializedEqual(td, storedTD) {
-			t.Fatalf("Expected:\n%v\nRetrieved:\n%v\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-		}
+		assertEqualTitle(t, td, storedTD)
 	})
 
 	t.Run("registration info", func(t *testing.T) {
@@ -106,7 +104,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 		b, _ := json.Marshal(td)
 
 		// submit PUT request
-		res, err := httpPut(serverURL+"/things", MediaTypeThingDescription, b)
+		res, err := httpPut(serverURL+"/things/", MediaTypeThingDescription, b)
 		if err != nil {
 			t.Fatalf("Error putting: %s", err)
 		}
@@ -124,7 +122,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 		b, _ := json.Marshal(td)
 
 		// submit POST request
-		res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
+		res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("Error posting: %s", err)
 		}
@@ -199,9 +197,7 @@ func TestCreateThing(t *testing.T) {
 		delete(td, "registration")
 		delete(storedTD, "registration")
 
-		if !serializedEqual(td, storedTD) {
-			t.Fatalf("Expected:\n%v\nRetrieved:\n%v\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-		}
+		assertEqualTitle(t, td, storedTD)
 	})
 
 	// t.Run("registration info", func(t *testing.T) {
@@ -284,7 +280,7 @@ func TestCreateThing(t *testing.T) {
 	// 	b, _ := json.Marshal(td)
 
 	// 	// submit POST request
-	// 	res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
+	// 	res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
 	// 	if err != nil {
 	// 		t.Fatalf( "Error posting: %s", err)
 	// 	}
@@ -350,9 +346,7 @@ func TestRetrieveThing(t *testing.T) {
 		// remove system-generated attributes
 		delete(retrievedTD, "registration")
 
-		if !serializedEqual(td, retrievedTD) {
-			t.Fatalf("Expected:\n%v\nRetrieved:\n%v", marshalPrettyJSON(td), marshalPrettyJSON(retrievedTD))
-		}
+		assertEqualTitle(t, td, retrievedTD)
 	})
 
 	t.Run("registration info", func(t *testing.T) {
@@ -427,10 +421,7 @@ func TestUpdateThing(t *testing.T) {
 		delete(td, "registration")
 		delete(storedTD, "registration")
 
-		if !serializedEqual(td, storedTD) {
-			t.Logf("Expected:\n%v\n Retrieved:\n%v\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-			t.Fatalf("Unexpected result body; see logs.")
-		}
+		assertEqualTitle(t, td, storedTD)
 	})
 
 	t.Run("reject invalid", func(t *testing.T) {
@@ -524,9 +515,7 @@ func TestPatch(t *testing.T) {
 			delete(td, "registration")
 			delete(storedTD, "registration")
 
-			if !serializedEqual(td, storedTD) {
-				t.Fatalf("Expected:\n%s\n Retrieved:\n%s\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-			}
+			assertEqualTitle(t, td, storedTD)
 		})
 	})
 
@@ -573,9 +562,7 @@ func TestPatch(t *testing.T) {
 			delete(td, "registration")
 			delete(storedTD, "registration")
 
-			if !serializedEqual(td, storedTD) {
-				t.Fatalf("Expected:\n%s\n Retrieved:\n%s\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-			}
+			assertEqualTitle(t, td, storedTD)
 		})
 	})
 
@@ -640,10 +627,7 @@ func TestPatch(t *testing.T) {
 			delete(td, "registration")
 			delete(storedTD, "registration")
 
-			if !serializedEqual(td, storedTD) {
-				t.Logf("Expected:\n%s\n Retrieved:\n%s\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-				t.Fatalf("Unexpected result body; see logs.")
-			}
+			assertEqualTitle(t, td, storedTD)
 		})
 	})
 
@@ -707,10 +691,7 @@ func TestPatch(t *testing.T) {
 			delete(td, "registration")
 			delete(storedTD, "registration")
 
-			if !serializedEqual(td, storedTD) {
-				t.Logf("Expected:\n%s\n Retrieved:\n%s\n", marshalPrettyJSON(td), marshalPrettyJSON(storedTD))
-				t.Fatalf("Unexpected result body; see logs.")
-			}
+			assertEqualTitle(t, td, storedTD)
 		})
 	})
 

--- a/directory/things_test.go
+++ b/directory/things_test.go
@@ -29,7 +29,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 			"tdd-things-create-anonymous-contenttype")
 
 		// submit POST request
-		res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
+		res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("Error posting: %s", err)
 		}
@@ -106,7 +106,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 		b, _ := json.Marshal(td)
 
 		// submit PUT request
-		res, err := httpPut(serverURL+"/things/", MediaTypeThingDescription, b)
+		res, err := httpPut(serverURL+"/things", MediaTypeThingDescription, b)
 		if err != nil {
 			t.Fatalf("Error putting: %s", err)
 		}
@@ -124,7 +124,7 @@ func TestCreateAnonymousThing(t *testing.T) {
 		b, _ := json.Marshal(td)
 
 		// submit POST request
-		res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
+		res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("Error posting: %s", err)
 		}
@@ -284,7 +284,7 @@ func TestCreateThing(t *testing.T) {
 	// 	b, _ := json.Marshal(td)
 
 	// 	// submit POST request
-	// 	res, err := http.Post(serverURL+"/things/", MediaTypeThingDescription, bytes.NewReader(b))
+	// 	res, err := http.Post(serverURL+"/things", MediaTypeThingDescription, bytes.NewReader(b))
 	// 	if err != nil {
 	// 		t.Fatalf( "Error posting: %s", err)
 	// 	}

--- a/directory/utilities.go
+++ b/directory/utilities.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"mime"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/r3labs/sse/v2"
@@ -171,17 +170,11 @@ func retrieveAllThings(serverURL string, t *testing.T) []mapAny {
 	return retrievedTDs
 }
 
-func serializedEqual(td1, td2 mapAny) bool {
-	// ignore context for now
-	// See https://github.com/w3c/wot-discovery/issues/291
-	delete(td1, "@context")
-	delete(td2, "@context")
-
-	// serialize to ease comparison of interfaces and concrete types
-	tdBytes, _ := json.Marshal(td1)
-	td2Bytes, _ := json.Marshal(td2)
-
-	return reflect.DeepEqual(tdBytes, td2Bytes)
+func assertEqualTitle(t *testing.T, expectedTD, retrievedTD mapAny) {
+	if expectedTD["title"] != retrievedTD["title"] {
+		t.Fatalf("Expected TD with title: %v, Got: %v",
+			expectedTD["title"], retrievedTD["title"])
+	}
 }
 
 func httpPut(url, contentType string, b []byte) (*http.Response, error) {


### PR DESCRIPTION
The comparison of the mock TD input and output from directory was done by serializing the objects to JSON and performing a bytes comparison. This was subject to failure when the directory was performing semantic processing and giving the output in another semantically equivalent representation. I replacing this with a simple `title` check. This is okay because the tests aren't really about making sure the directory returns the exact TD, but rather about making sure the workflows are based on specified assertion. Fine grained tests on exact input and matching output should be done independently as unit tests.

- Close #24 
- Close #26 
- Close #9

We could perform comparison on expanded JSON-LD objects, if someone can come up with a working solution.