### PR TITLE
Report failures on dependency errors

### DIFF
--- a/directory/README.md
+++ b/directory/README.md
@@ -18,6 +18,10 @@ Useful CLI Arguments:
 ```
 --server string
         URL of the directory service
+-testJSONPath
+        perform informative JSONPath testing
+-testXPath
+        perform informative XPath testing
 -v
         verbose: print additional output
 --run regexp

--- a/directory/main_test.go
+++ b/directory/main_test.go
@@ -15,11 +15,16 @@ const (
 	MediaTypeMergePatch       = "application/merge-patch+json"
 )
 
-var serverURL string
+var (
+	serverURL               string
+	testJSONPath, testXPath bool
+)
 
 func TestMain(m *testing.M) {
 	// CLI arguments
 	reportPath := flag.String("report", "", "Path to create report")
+	flag.BoolVar(&testJSONPath, "testJSONPath", false, "Enable JSONPath testing")
+	flag.BoolVar(&testXPath, "testXPath", false, "Enable XPath testing")
 	flag.StringVar(&serverURL, "server", "", "Base URL of the directory service")
 	flag.Parse()
 

--- a/directory/main_test.go
+++ b/directory/main_test.go
@@ -20,7 +20,7 @@ var serverURL string
 func TestMain(m *testing.M) {
 	// CLI arguments
 	reportPath := flag.String("report", "", "Path to create report")
-	flag.StringVar(&serverURL, "server", "", "URL of the directory service")
+	flag.StringVar(&serverURL, "server", "", "Base URL of the directory service")
 	flag.Parse()
 
 	if *reportPath != "" {

--- a/directory/report.go
+++ b/directory/report.go
@@ -45,7 +45,7 @@ func initReportWriter() (commit func()) {
 	return func() {
 		// Generate auto testing report
 		// convert to csv records (2D slice)
-	var resultsSlice [][]string
+		var resultsSlice [][]string
 		for id, result := range results {
 			resultsSlice = append(resultsSlice, resultToCSVRecord(id, result))
 		}
@@ -72,8 +72,8 @@ func initReportWriter() (commit func()) {
 				fmt.Println("-", id)
 			}
 		}
-		}
 	}
+}
 
 // loadAssertions returns the list of assertions.
 // It will read from a local file.
@@ -215,6 +215,13 @@ func report(t *testing.T, assertions ...string) {
 	}
 
 	insertRecord(t, t.Name(), assertions)
+}
+
+// report at the end of tests. Execute with defer statement.
+func reportGroup(t *testing.T, assertionGroups ...[]string) {
+	for _, ag := range assertionGroups {
+		report(t, ag...)
+	}
 }
 
 func inSlice(s []string, e string) bool {

--- a/directory/report.go
+++ b/directory/report.go
@@ -65,12 +65,16 @@ func initReportWriter() (commit func()) {
 		}
 		writeCSVReport(manualReportFile, manualList)
 
-		fmt.Println("\nWarning: The following tested assertions do not exist in the list of normative assertions:")
+		// find invalid assertions
+		var invalidAssertions []string
 		for i := range resultsSlice {
 			id := resultsSlice[i][0]
 			if !inSlice(tddAssertions, id) {
-				fmt.Println("-", id)
+				invalidAssertions = append(invalidAssertions, id)
 			}
+		}
+		if len(invalidAssertions) > 0 {
+			fmt.Printf("\nWarning: The following tested assertions do not exist in the list of normative assertions: %v\n\n", invalidAssertions)
 		}
 	}
 }

--- a/directory/search_test.go
+++ b/directory/search_test.go
@@ -93,39 +93,6 @@ func TestJSONPath(t *testing.T) {
 		})
 	})
 
-	t.Run("filter anonymous", func(t *testing.T) {
-		defer report(t, "tdd-anonymous-td-identifier")
-
-		// add an anonymous TD
-		createdTD := mockedTD("") // no id
-		// tag the TDs to find later
-		tag := uuid.NewV4().String()
-		createdTD["tag"] = tag
-		createThing("", createdTD, serverURL, t)
-
-		// submit the request
-		response, err := http.Get(serverURL + fmt.Sprintf("/search/jsonpath?query=$[?(@.tag=='%s')]", tag))
-		if err != nil {
-			t.Fatalf("Error getting TDs: %s", err)
-		}
-		defer response.Body.Close()
-
-		body := httpReadBody(response, t)
-
-		var filterredTDs []mapAny
-		err = json.Unmarshal(body, &filterredTDs)
-		if err != nil {
-			t.Fatalf("Error decoding page: %s", err)
-		}
-
-		if len(filterredTDs) != 1 {
-			t.Fatalf("Filtering returned %d TDs, expected 1", len(filterredTDs))
-		}
-
-		// try to get the ID. This should pass
-		getID(t, filterredTDs[0])
-	})
-
 	t.Run("reject bad query", func(t *testing.T) {
 		var response *http.Response
 
@@ -231,39 +198,6 @@ func TestXPath(t *testing.T) {
 				assertEqualTitle(t, createdTDsMap[id], filterredTD)
 			}
 		})
-	})
-
-	t.Run("filter anonymous", func(t *testing.T) {
-		defer report(t, "tdd-anonymous-td-identifier")
-
-		// add an anonymous TD
-		createdTD := mockedTD("") // no id
-		// tag the TDs to find later
-		tag := uuid.NewV4().String()
-		createdTD["tag"] = tag
-		createThing("", createdTD, serverURL, t)
-
-		// submit the request
-		response, err := http.Get(serverURL + fmt.Sprintf("/search/xpath?query=*[tag='%s']", tag))
-		if err != nil {
-			t.Fatalf("Error getting TDs: %s", err)
-		}
-		defer response.Body.Close()
-
-		body := httpReadBody(response, t)
-
-		var filterredTDs []mapAny
-		err = json.Unmarshal(body, &filterredTDs)
-		if err != nil {
-			t.Fatalf("Error decoding page: %s", err)
-		}
-
-		if len(filterredTDs) != 1 {
-			t.Fatalf("Filtering returned %d TDs, expected 1", len(filterredTDs))
-		}
-
-		// try to get the ID. This should pass
-		getID(t, filterredTDs[0])
 	})
 
 	t.Run("reject bad query", func(t *testing.T) {

--- a/directory/search_test.go
+++ b/directory/search_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestJSONPath(t *testing.T) {
+	if !testJSONPath {
+		t.Skip("Not enabled.")
+	}
 
 	t.Run("filter", func(t *testing.T) {
 		tag := uuid.NewV4().String()
@@ -120,6 +123,10 @@ func TestJSONPath(t *testing.T) {
 }
 
 func TestXPath(t *testing.T) {
+	if !testXPath {
+		t.Skip("Not enabled.")
+	}
+
 	t.Run("filter", func(t *testing.T) {
 		tag := uuid.NewV4().String()
 		var createdTD []mapAny

--- a/directory/search_test.go
+++ b/directory/search_test.go
@@ -234,6 +234,14 @@ func TestXPath(t *testing.T) {
 }
 
 func TestSPARQL(t *testing.T) {
+	defer report(t,
+		"tdd-search-sparql",
+		"tdd-search-sparql-method-get",
+		"tdd-search-sparql-resp-select-ask",
+		"tdd-search-sparql-method-post",
+		"tdd-search-sparql-federation",
+		"tdd-http-head", // need to skip this if SPARQL GET isn't implemented
+	)
 
 	const query = `select * { ?s ?p ?o }limit 5`
 	const federatedQuery = `select * {
@@ -257,6 +265,8 @@ func TestSPARQL(t *testing.T) {
 			t.Fatalf("Error solving query SPARQL: %s", err)
 		}
 		body := httpReadBody(res, t)
+
+		assertStatusCode(t, res, http.StatusOK, body)
 
 		var responseMap mapAny
 		err = json.Unmarshal(body, &responseMap)
@@ -286,6 +296,8 @@ func TestSPARQL(t *testing.T) {
 		}
 		body := httpReadBody(res, t)
 
+		assertStatusCode(t, res, http.StatusOK, body)
+
 		var responseMap mapAny
 		err = json.Unmarshal(body, &responseMap)
 		if err != nil {
@@ -312,6 +324,8 @@ func TestSPARQL(t *testing.T) {
 			t.Fatalf("Error solving query SPARQL: %s", err)
 		}
 		body := httpReadBody(res, t)
+
+		assertStatusCode(t, res, http.StatusOK, body)
 
 		var responseMap mapAny
 		err = json.Unmarshal(body, &responseMap)

--- a/directory/things_test.go
+++ b/directory/things_test.go
@@ -155,7 +155,7 @@ func TestCreateThing(t *testing.T) {
 		"tdd-things-crud",
 		"tdd-things-crudl",
 		"tdd-things-create-known-td",
-		"tdd-things-create-known-contenttype",
+		// "tdd-things-create-known-contenttype", // not tested
 		"tdd-things-create-known-td-resp",
 		"tdd-validation-syntactic",
 		"tdd-http-error-response",
@@ -173,13 +173,12 @@ func TestCreateThing(t *testing.T) {
 		defer report(t,
 			"tdd-things-crud",
 			"tdd-things-crudl",
-			"tdd-things-create-known-td",
-			"tdd-things-create-known-contenttype")
+			"tdd-things-create-known-td")
 
 		// submit PUT request
 		res, err := httpPut(serverURL+"/things/"+id, MediaTypeThingDescription, b)
 		if err != nil {
-			t.Errorf("Error posting: %s", err)
+			t.Fatalf("Error posting: %s", err)
 		}
 		response = res
 		// defer res.Body.Close()
@@ -291,14 +290,19 @@ func TestRetrieveThing(t *testing.T) {
 		assertEqualTitle(t, td, retrievedTD)
 	})
 
-	t.Run("registration info", func(t *testing.T) {
-		defer report(t,
-			"tdd-registrationinfo-vocab-created",
-			"tdd-registrationinfo-vocab-modified")
+	t.Run("registrationInfo created", func(t *testing.T) {
+		defer report(t, "tdd-registrationinfo-vocab-created")
 		// retrieve the stored TD
 		storedTD := retrieveThing(id, serverURL, t)
 
 		testRegistrationInfoCreated(t, storedTD)
+	})
+
+	t.Run("registrationInfo modified", func(t *testing.T) {
+		defer report(t, "tdd-registrationinfo-vocab-modified")
+		// retrieve the stored TD
+		storedTD := retrieveThing(id, serverURL, t)
+
 		testRegistrationInfoModified(t, storedTD)
 	})
 
@@ -713,56 +717,30 @@ func TestDelete(t *testing.T) {
 	td := mockedTD(id)
 	createThing(id, td, serverURL, t)
 
-	t.Run("existing", func(t *testing.T) {
-		var response *http.Response
+	var response *http.Response
 
-		t.Run("submit request", func(t *testing.T) {
-			defer report(t,
-				"tdd-things-crud",
-				"tdd-things-crudl",
-				"tdd-things-delete")
+	t.Run("submit request", func(t *testing.T) {
+		defer report(t,
+			"tdd-things-crud",
+			"tdd-things-crudl",
+			"tdd-things-delete")
 
-			// submit DELETE request
-			res, err := httpDelete(serverURL + "/things/" + id)
-			if err != nil {
-				t.Fatalf("Error deleting TD: %s", err)
-			}
-			// defer res.Body.Close()
-			response = res
-		})
-
-		body := httpReadBody(response, t)
-
-		t.Run("status code", func(t *testing.T) {
-			defer report(t, "tdd-things-delete-resp")
-
-			assertStatusCode(t, response, http.StatusNoContent, body)
-		})
+		// submit DELETE request
+		res, err := httpDelete(serverURL + "/things/" + id)
+		if err != nil {
+			t.Fatalf("Error deleting TD: %s", err)
+		}
+		// defer res.Body.Close()
+		response = res
 	})
 
-	t.Run("non-existing", func(t *testing.T) {
-		var response *http.Response
+	body := httpReadBody(response, t)
 
-		t.Run("submit request", func(t *testing.T) {
-			defer report(t, "tdd-things-delete")
+	t.Run("status code", func(t *testing.T) {
+		defer report(t, "tdd-things-delete-resp")
 
-			// submit DELETE request
-			res, err := httpDelete(serverURL + "/things/non-exiting-td")
-			if err != nil {
-				t.Fatalf("Error deleting TD: %s", err)
-			}
-			// defer res.Body.Close()
-			response = res
-		})
-
-		body := httpReadBody(response, t)
-
-		t.Run("status code", func(t *testing.T) {
-			defer report(t, "tdd-things-delete-resp")
-			assertStatusCode(t, response, http.StatusNotFound, body)
-		})
+		assertStatusCode(t, response, http.StatusNoContent, body)
 	})
-
 }
 
 func TestListThings(t *testing.T) {
@@ -848,7 +826,7 @@ func TestListThings(t *testing.T) {
 		}
 	})
 
-	t.Run("RegistrationInfo created", func(t *testing.T) {
+	t.Run("registrationInfo created", func(t *testing.T) {
 		defer report(t, "tdd-registrationinfo-vocab-created")
 
 		var collection []mapAny
@@ -865,7 +843,7 @@ func TestListThings(t *testing.T) {
 		testRegistrationInfoCreated(t, collection[0])
 	})
 
-	t.Run("RegistrationInfo modified", func(t *testing.T) {
+	t.Run("registrationInfo modified", func(t *testing.T) {
 		defer report(t, "tdd-registrationinfo-vocab-modified")
 
 		var collection []mapAny

--- a/directory/things_test.go
+++ b/directory/things_test.go
@@ -12,9 +12,51 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// http-head
-
 func TestCreateAnonymousThing(t *testing.T) {
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-crud",
+		"tdd-things-crudl",
+		"tdd-things-create-anonymous-td",
+		"tdd-things-create-anonymous-contenttype",
+		"tdd-things-create-anonymous-td-resp",
+		"tdd-things-create-anonymous-td-resp",
+		"tdd-anonymous-td-local-uuid",
+		"tdd-anonymous-td-identifier",
+		"tdd-things-create-known-vs-anonymous",
+		"tdd-http-error-response",
+		"tdd-validation-syntactic",
+		"tdd-validation-result",
+		"tdd-validation-response",
+	)
+	// var (
+	// 	request = []string{
+	// 		"tdd-things-crud",
+	// 		"tdd-things-crudl",
+	// 		"tdd-things-create-anonymous-td",
+	// 		"tdd-things-create-anonymous-contenttype",
+	// 	}
+	// 	statusCode = []string{
+	// 		"tdd-things-create-anonymous-td-resp",
+	// 	}
+	// 	locationHeader = []string{
+	// 		"tdd-things-create-anonymous-td-resp",
+	// 		"tdd-anonymous-td-local-uuid",
+	// 	}
+	// 	tdIdentifier = []string{
+	// 		"tdd-anonymous-td-identifier",
+	// 	}
+	// 	rejectAnonymousPUT = []string{
+	// 		"tdd-things-create-known-vs-anonymous",
+	// 	}
+	// 	badRequest = []string{
+	// 		"tdd-validation-syntactic",
+	// 		"tdd-http-error-response",
+	// 		"tdd-validation-result",
+	// 		"tdd-validation-response",
+	// 	}
+	// )
+	// defer reportGroup(t, request, statusCode, badRequest)
 
 	td := mockedTD("") // without ID
 	b, _ := json.Marshal(td)
@@ -67,24 +109,6 @@ func TestCreateAnonymousThing(t *testing.T) {
 		if !strings.Contains(systemGeneratedID, "urn:uuid:") {
 			t.Fatalf("System-generated ID doesn't have URN UUID scheme. Got: %s", location)
 		}
-	})
-
-	t.Run("result", func(t *testing.T) {
-		defer report(t, "tdd-things-create-anonymous-td")
-
-		if systemGeneratedID == "" {
-			t.Fatalf("previous errors")
-		}
-
-		// retrieve the stored TD
-		storedTD := retrieveThing(systemGeneratedID, serverURL, t)
-
-		// remove system-generated attributes
-		delete(td, "registration")
-		delete(storedTD, "registration")
-		delete(storedTD, "id")
-
-		assertEqualTitle(t, td, storedTD)
 	})
 
 	t.Run("registration info", func(t *testing.T) {
@@ -154,24 +178,36 @@ func TestCreateAnonymousThing(t *testing.T) {
 }
 
 func TestCreateThing(t *testing.T) {
-	var (
-		request = []string{
-			"tdd-things-crud",
-			"tdd-things-crudl",
-			"tdd-things-create-known-td",
-			"tdd-things-create-known-contenttype",
-		}
-		statusCode = []string{
-			"tdd-things-create-known-td-resp",
-		}
-		badRequest = []string{
-			"tdd-validation-syntactic",
-			"tdd-http-error-response",
-			"tdd-validation-result",
-			"tdd-validation-response",
-		}
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-crud",
+		"tdd-things-crudl",
+		"tdd-things-create-known-td",
+		"tdd-things-create-known-contenttype",
+		"tdd-things-create-known-td-resp",
+		"tdd-validation-syntactic",
+		"tdd-http-error-response",
+		"tdd-validation-result",
+		"tdd-validation-response",
 	)
-	defer reportGroup(t, request, statusCode, badRequest)
+	// var (
+	// 	request = []string{
+	// 		"tdd-things-crud",
+	// 		"tdd-things-crudl",
+	// 		"tdd-things-create-known-td",
+	// 		"tdd-things-create-known-contenttype",
+	// 	}
+	// 	statusCode = []string{
+	// 		"tdd-things-create-known-td-resp",
+	// 	}
+	// 	badRequest = []string{
+	// 		"tdd-validation-syntactic",
+	// 		"tdd-http-error-response",
+	// 		"tdd-validation-result",
+	// 		"tdd-validation-response",
+	// 	}
+	// )
+	// defer reportGroup(t, request, statusCode, badRequest)
 
 	id := "urn:uuid:" + uuid.NewV4().String()
 	td := mockedTD(id)
@@ -180,7 +216,11 @@ func TestCreateThing(t *testing.T) {
 	var response *http.Response
 
 	t.Run("request", func(t *testing.T) {
-		defer report(t, request...)
+		defer report(t,
+			"tdd-things-crud",
+			"tdd-things-crudl",
+			"tdd-things-create-known-td",
+			"tdd-things-create-known-contenttype")
 
 		// submit PUT request
 		res, err := httpPut(serverURL+"/things/"+id, MediaTypeThingDescription, b)

--- a/directory/things_test.go
+++ b/directory/things_test.go
@@ -29,34 +29,6 @@ func TestCreateAnonymousThing(t *testing.T) {
 		"tdd-validation-result",
 		"tdd-validation-response",
 	)
-	// var (
-	// 	request = []string{
-	// 		"tdd-things-crud",
-	// 		"tdd-things-crudl",
-	// 		"tdd-things-create-anonymous-td",
-	// 		"tdd-things-create-anonymous-contenttype",
-	// 	}
-	// 	statusCode = []string{
-	// 		"tdd-things-create-anonymous-td-resp",
-	// 	}
-	// 	locationHeader = []string{
-	// 		"tdd-things-create-anonymous-td-resp",
-	// 		"tdd-anonymous-td-local-uuid",
-	// 	}
-	// 	tdIdentifier = []string{
-	// 		"tdd-anonymous-td-identifier",
-	// 	}
-	// 	rejectAnonymousPUT = []string{
-	// 		"tdd-things-create-known-vs-anonymous",
-	// 	}
-	// 	badRequest = []string{
-	// 		"tdd-validation-syntactic",
-	// 		"tdd-http-error-response",
-	// 		"tdd-validation-result",
-	// 		"tdd-validation-response",
-	// 	}
-	// )
-	// defer reportGroup(t, request, statusCode, badRequest)
 
 	td := mockedTD("") // without ID
 	b, _ := json.Marshal(td)
@@ -190,24 +162,6 @@ func TestCreateThing(t *testing.T) {
 		"tdd-validation-result",
 		"tdd-validation-response",
 	)
-	// var (
-	// 	request = []string{
-	// 		"tdd-things-crud",
-	// 		"tdd-things-crudl",
-	// 		"tdd-things-create-known-td",
-	// 		"tdd-things-create-known-contenttype",
-	// 	}
-	// 	statusCode = []string{
-	// 		"tdd-things-create-known-td-resp",
-	// 	}
-	// 	badRequest = []string{
-	// 		"tdd-validation-syntactic",
-	// 		"tdd-http-error-response",
-	// 		"tdd-validation-result",
-	// 		"tdd-validation-response",
-	// 	}
-	// )
-	// defer reportGroup(t, request, statusCode, badRequest)
 
 	id := "urn:uuid:" + uuid.NewV4().String()
 	td := mockedTD(id)
@@ -273,6 +227,17 @@ func TestCreateThing(t *testing.T) {
 }
 
 func TestRetrieveThing(t *testing.T) {
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-crud",
+		"tdd-things-crudl",
+		"tdd-things-retrieve",
+		"tdd-things-default-representation",
+		"tdd-things-retrieve-resp",
+		"tdd-registrationinfo-vocab-created",
+		"tdd-registrationinfo-vocab-modified",
+		"tdd-http-head",
+	)
 
 	// add a new TD
 	id := "urn:uuid:" + uuid.NewV4().String()
@@ -311,7 +276,7 @@ func TestRetrieveThing(t *testing.T) {
 		assertContentMediaType(t, response, MediaTypeThingDescription)
 	})
 
-	t.Run("result", func(t *testing.T) {
+	t.Run("payload", func(t *testing.T) {
 		defer report(t, "tdd-things-retrieve")
 
 		var retrievedTD mapAny
@@ -327,10 +292,14 @@ func TestRetrieveThing(t *testing.T) {
 	})
 
 	t.Run("registration info", func(t *testing.T) {
+		defer report(t,
+			"tdd-registrationinfo-vocab-created",
+			"tdd-registrationinfo-vocab-modified")
 		// retrieve the stored TD
 		storedTD := retrieveThing(id, serverURL, t)
 
-		testRegistrionInfo(t, storedTD)
+		testRegistrationInfoCreated(t, storedTD)
+		testRegistrationInfoModified(t, storedTD)
 	})
 
 	// t.Run("anonymous td id", func(t *testing.T) {
@@ -352,6 +321,19 @@ func TestRetrieveThing(t *testing.T) {
 }
 
 func TestUpdateThing(t *testing.T) {
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-crud",
+		"tdd-things-crudl",
+		"tdd-things-update",
+		"tdd-things-update-contenttype",
+		"tdd-things-update-resp",
+		"tdd-things-update-contenttype",
+		"tdd-validation-syntactic",
+		"tdd-http-error-response",
+		"tdd-validation-result",
+		"tdd-validation-response",
+	)
 
 	// add a new TD
 	id := "urn:uuid:" + uuid.NewV4().String()
@@ -369,7 +351,7 @@ func TestUpdateThing(t *testing.T) {
 			"tdd-things-crud",
 			"tdd-things-crudl",
 			"tdd-things-update",
-			"tdd-things-update-contenttype",
+			// "tdd-things-update-contenttype", // not tested
 		)
 
 		// submit PUT request
@@ -388,8 +370,8 @@ func TestUpdateThing(t *testing.T) {
 		assertStatusCode(t, response, http.StatusNoContent, body)
 	})
 
-	t.Run("result", func(t *testing.T) {
-		defer report(t, "tdd-things-update", "tdd-things-update-contenttype")
+	t.Run("payload", func(t *testing.T) {
+		defer report(t, "tdd-things-update")
 
 		// retrieve the stored TD
 		storedTD := retrieveThing(id, serverURL, t)
@@ -435,7 +417,6 @@ func TestUpdateThing(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
-
 	var (
 		requestAssertions = []string{
 			"tdd-things-update-partial",
@@ -448,6 +429,14 @@ func TestPatch(t *testing.T) {
 			"tdd-things-update-partial-mergepatch",
 		}
 	)
+	// initialize related assertions
+	defer reportGroup(t, requestAssertions, statusAssertions, resultAssertions,
+		[]string{
+			"tdd-validation-syntactic",
+			"tdd-http-error-response",
+			"tdd-validation-result",
+			"tdd-validation-response",
+		})
 
 	t.Run("replace title", func(t *testing.T) {
 		// add a new TD
@@ -711,11 +700,12 @@ func TestPatch(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-
-	const (
-		requestAssertions = "tdd-things-delete"
-		statusAssertions  = "tdd-things-delete-resp"
-		resultAssertions  = "tdd-things-delete"
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-crud",
+		"tdd-things-crudl",
+		"tdd-things-delete",
+		"tdd-things-delete-resp",
 	)
 
 	// add a new TD
@@ -730,7 +720,7 @@ func TestDelete(t *testing.T) {
 			defer report(t,
 				"tdd-things-crud",
 				"tdd-things-crudl",
-				requestAssertions)
+				"tdd-things-delete")
 
 			// submit DELETE request
 			res, err := httpDelete(serverURL + "/things/" + id)
@@ -744,26 +734,9 @@ func TestDelete(t *testing.T) {
 		body := httpReadBody(response, t)
 
 		t.Run("status code", func(t *testing.T) {
-			defer report(t, statusAssertions)
+			defer report(t, "tdd-things-delete-resp")
 
 			assertStatusCode(t, response, http.StatusNoContent, body)
-		})
-
-		t.Run("result", func(t *testing.T) {
-			defer report(t, resultAssertions)
-
-			// try to retrieve the deleted TD
-			res, err := http.Get(serverURL + "/things/" + id)
-			if err != nil {
-				t.Fatalf("Error getting TD: %s", err)
-			}
-			defer res.Body.Close()
-
-			body = httpReadBody(res, t)
-
-			t.Run("status code", func(t *testing.T) {
-				assertStatusCode(t, res, http.StatusNotFound, body)
-			})
 		})
 	})
 
@@ -771,7 +744,7 @@ func TestDelete(t *testing.T) {
 		var response *http.Response
 
 		t.Run("submit request", func(t *testing.T) {
-			defer report(t, requestAssertions)
+			defer report(t, "tdd-things-delete")
 
 			// submit DELETE request
 			res, err := httpDelete(serverURL + "/things/non-exiting-td")
@@ -785,7 +758,7 @@ func TestDelete(t *testing.T) {
 		body := httpReadBody(response, t)
 
 		t.Run("status code", func(t *testing.T) {
-			defer report(t, statusAssertions)
+			defer report(t, "tdd-things-delete-resp")
 			assertStatusCode(t, response, http.StatusNotFound, body)
 		})
 	})
@@ -793,6 +766,19 @@ func TestDelete(t *testing.T) {
 }
 
 func TestListThings(t *testing.T) {
+	// initialize related assertions
+	defer report(t,
+		"tdd-things-list-only",
+		"tdd-things-crudl",
+		"tdd-things-list-method",
+		"tdd-things-default-representation",
+		"tdd-things-list-resp",
+		"tdd-registrationinfo-vocab-created",
+		"tdd-registrationinfo-vocab-modified",
+		"tdd-anonymous-td-identifier",
+		"tdd-http-head",
+	)
+
 	var response *http.Response
 	var body []byte
 
@@ -801,7 +787,8 @@ func TestListThings(t *testing.T) {
 		defer report(t,
 			"tdd-things-list-only",
 			"tdd-things-crudl",
-			"tdd-things-list-method")
+			"tdd-things-list-method",
+		)
 
 		for i := 0; i < 3; i++ {
 			id := "urn:uuid:" + uuid.NewV4().String()
@@ -861,8 +848,8 @@ func TestListThings(t *testing.T) {
 		}
 	})
 
-	t.Run("registration info", func(t *testing.T) {
-		defer report(t, "tdd-things-list-resp")
+	t.Run("RegistrationInfo created", func(t *testing.T) {
+		defer report(t, "tdd-registrationinfo-vocab-created")
 
 		var collection []mapAny
 		err := json.Unmarshal(body, &collection)
@@ -875,7 +862,24 @@ func TestListThings(t *testing.T) {
 		}
 
 		// just test the first TD
-		testRegistrionInfo(t, collection[0])
+		testRegistrationInfoCreated(t, collection[0])
+	})
+
+	t.Run("RegistrationInfo modified", func(t *testing.T) {
+		defer report(t, "tdd-registrationinfo-vocab-modified")
+
+		var collection []mapAny
+		err := json.Unmarshal(body, &collection)
+		if err != nil {
+			t.Fatalf("Error decoding page: %s", err)
+		}
+
+		if len(collection) == 0 {
+			t.Fatalf("Unexpected empty collection.")
+		}
+
+		// just test the first TD
+		testRegistrationInfoCreated(t, collection[0])
 	})
 
 	t.Run("anonymous td id", func(t *testing.T) {
@@ -950,67 +954,64 @@ func TestListThings(t *testing.T) {
 
 }
 
-func testRegistrionInfo(t *testing.T, td mapAny) {
+func testRegistrationInfoCreated(t *testing.T, td mapAny) {
+	// defer report(t, "tdd-registrationinfo-vocab-created")
 
-	t.Run("created", func(t *testing.T) {
-		defer report(t, "tdd-registrationinfo-vocab-created")
+	regInfo, ok := td["registration"].(mapAny)
+	if !ok {
+		t.Fatalf("invalid or missing registration object: %v", td["registration"])
+	}
 
-		regInfo, ok := td["registration"].(mapAny)
-		if !ok {
-			t.Fatalf("invalid or missing registration object: %v", td["registration"])
-		}
-
-		createdStr, ok := regInfo["created"].(string)
-		if !ok {
-			t.Fatalf("invalid or missing registration.created: %v", regInfo["created"])
-		}
-		created, err := time.Parse(time.RFC3339, createdStr)
-		if err != nil {
-			t.Fatalf("invalid registration.created format: %s", err)
-		}
-		age := time.Since(created)
-		if age < 0 && age > time.Minute {
-			t.Fatalf("registration.created is in future or too old: %s", created)
-		}
-	})
-
-	t.Run("modified", func(t *testing.T) {
-		defer report(t, "tdd-registrationinfo-vocab-modified")
-
-		regInfo, ok := td["registration"].(mapAny)
-		if !ok {
-			t.Fatalf("invalid or missing registration object: %v", td["registration"])
-		}
-
-		modifiedStr, ok := regInfo["modified"].(string)
-		if !ok {
-			t.Fatalf("invalid or missing registration.modified: %v", regInfo["modified"])
-		}
-		modified, err := time.Parse(time.RFC3339, modifiedStr)
-		if err != nil {
-			t.Fatalf("invalid registration.modified format: %s", err)
-		}
-		age := time.Since(modified)
-		if age < 0 && age > time.Minute {
-			t.Fatalf("registration.modified is in future or too old: %s", modified)
-		}
-	})
-
-	// t.Run("expires", func(t *testing.T) {
-	// 	defer report(t, "tdd-registrationinfo-vocab-expires")
-
-	// 	t.Skipf("TODO")
-	// })
-
-	// t.Run("ttl", func(t *testing.T) {
-	// 	defer report(t, "tdd-registrationinfo-vocab-ttl")
-
-	// 	t.Skipf("TODO")
-	// })
-
-	// t.Run("retrieved", func(t *testing.T) {
-	// 	defer report(t, "tdd-registrationinfo-vocab-retrieved")
-
-	// 	t.Skipf("TODO")
-	// })
+	createdStr, ok := regInfo["created"].(string)
+	if !ok {
+		t.Fatalf("invalid or missing registration.created: %v", regInfo["created"])
+	}
+	created, err := time.Parse(time.RFC3339, createdStr)
+	if err != nil {
+		t.Fatalf("invalid registration.created format: %s", err)
+	}
+	age := time.Since(created)
+	if age < 0 && age > time.Minute {
+		t.Fatalf("registration.created is in future or too old: %s", created)
+	}
 }
+
+func testRegistrationInfoModified(t *testing.T, td mapAny) {
+	// defer report(t, "tdd-registrationinfo-vocab-modified")
+
+	regInfo, ok := td["registration"].(mapAny)
+	if !ok {
+		t.Fatalf("invalid or missing registration object: %v", td["registration"])
+	}
+
+	modifiedStr, ok := regInfo["modified"].(string)
+	if !ok {
+		t.Fatalf("invalid or missing registration.modified: %v", regInfo["modified"])
+	}
+	modified, err := time.Parse(time.RFC3339, modifiedStr)
+	if err != nil {
+		t.Fatalf("invalid registration.modified format: %s", err)
+	}
+	age := time.Since(modified)
+	if age < 0 && age > time.Minute {
+		t.Fatalf("registration.modified is in future or too old: %s", modified)
+	}
+}
+
+// t.Run("expires", func(t *testing.T) {
+// 	defer report(t, "tdd-registrationinfo-vocab-expires")
+
+// 	t.Skipf("TODO")
+// })
+
+// t.Run("ttl", func(t *testing.T) {
+// 	defer report(t, "tdd-registrationinfo-vocab-ttl")
+
+// 	t.Skipf("TODO")
+// })
+
+// t.Run("retrieved", func(t *testing.T) {
+// 	defer report(t, "tdd-registrationinfo-vocab-retrieved")
+
+// 	t.Skipf("TODO")
+// })


### PR DESCRIPTION
Some test depend on each other. For example, the status code after creating a TD depends on the successful creation. When a dependency fails, the following dependents end up in manual.csv (implemented by #34).

This PR does some refactoring to allow correct generation of manual report.

Additional changed:
- Remove anonymous TD filtering
- Remove result checking (e.g. query after creation)
- Remove commented / skipped tests
- Split registration info tests
- Remove delete non-existing test
- Add status code checks to SPARQL tests
- Disable JSONPath/XPath tests by default. Add CLI flag to enable.